### PR TITLE
Update DNA sequencing endpoint to use new ngrok URL and add ngrok-ski…

### DIFF
--- a/frontend/src/app/(app)/dna-sequencing/page.tsx
+++ b/frontend/src/app/(app)/dna-sequencing/page.tsx
@@ -164,7 +164,7 @@ export default function DNASequencingPage() {
             <div>
               <span className="font-medium">Server URL:</span>
               <p className="text-muted-foreground font-mono">
-                http://spit-on-that-thing.local:8002
+                https://3054cc94ecee.ngrok-free.app
               </p>
             </div>
             <div>

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -13,8 +13,8 @@ export const API_CONFIG = {
   // Genome device server (new) - Physical device on local network
   // Direct connection from browser to local Raspberry Pi (HTTP)
   GENOME_DEVICE: typeof window !== 'undefined'
-    ? (window as any).ENV?.NEXT_PUBLIC_GENOME_DEVICE_URL || 'http://spit-on-that-thing.local:8002'
-    : 'http://spit-on-that-thing.local:8002',
+    ? (window as any).ENV?.NEXT_PUBLIC_GENOME_DEVICE_URL || 'https://3054cc94ecee.ngrok-free.app'
+    : 'https://3054cc94ecee.ngrok-free.app',
   
   // HumanID backend (existing)
   HUMANID_BACKEND: typeof window !== 'undefined'

--- a/frontend/src/lib/dna-sequencing.ts
+++ b/frontend/src/lib/dna-sequencing.ts
@@ -35,6 +35,9 @@ export class DNASequencingService {
       console.log('🏥 Checking genome device health at:', API_ENDPOINTS.GENOME_DEVICE.HEALTH);
       const response = await fetch(API_ENDPOINTS.GENOME_DEVICE.HEALTH, {
         mode: 'cors',
+        headers: {
+          'ngrok-skip-browser-warning': 'true',
+        },
       });
       console.log('🏥 Health check response:', response.status, response.statusText);
       return response.ok;
@@ -58,6 +61,7 @@ export class DNASequencingService {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'ngrok-skip-browser-warning': 'true',
         },
         body: JSON.stringify(request),
         mode: 'cors', // Explicitly set CORS mode
@@ -98,7 +102,11 @@ export class DNASequencingService {
    */
   async getStatus(userId: string): Promise<SequencingStatus | null> {
     try {
-      const response = await fetch(API_ENDPOINTS.GENOME_DEVICE.STATUS(userId));
+      const response = await fetch(API_ENDPOINTS.GENOME_DEVICE.STATUS(userId), {
+        headers: {
+          'ngrok-skip-browser-warning': 'true',
+        },
+      });
       
       if (!response.ok) {
         if (response.status === 404) {
@@ -156,7 +164,11 @@ export class DNASequencingService {
    */
   async getAllStatuses(): Promise<SequencingStatus[]> {
     try {
-      const response = await fetch(API_ENDPOINTS.GENOME_DEVICE.LIST_STATUS);
+      const response = await fetch(API_ENDPOINTS.GENOME_DEVICE.LIST_STATUS, {
+        headers: {
+          'ngrok-skip-browser-warning': 'true',
+        },
+      });
       
       if (!response.ok) {
         throw new Error('Failed to get all statuses');


### PR DESCRIPTION
…p-browser-warning header

- Updated GENOME_DEVICE endpoint from local URL to https://3054cc94ecee.ngrok-free.app
- Added ngrok-skip-browser-warning header to all API requests in DNA sequencing service
- Updated display URL in DNA sequencing page to show correct endpoint
- Fixed bioinformatics analysis to properly use VCF file path
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the genome device endpoint to https://3054cc94ecee.ngrok-free.app and added the ngrok-skip-browser-warning header to all DNA sequencing requests to bypass the ngrok warning page. Updated the server URL displayed on the DNA sequencing page.

- **Bug Fixes**
  - Use the correct VCF file path in bioinformatics analysis.

<!-- End of auto-generated description by cubic. -->

