### PR TITLE
Fix Golem DB client initialization error

### DIFF
--- a/biometrics_server/golem_endpoints.py
+++ b/biometrics_server/golem_endpoints.py
@@ -39,17 +39,26 @@ async def get_golem_client() -> GolemBaseClient:
         if not PRIVATE_KEY:
             raise ValueError("PRIVATE_KEY environment variable is required")
         
-        golem_client = await GolemBaseClient.create_rw_client(
-            GOLEM_DB_RPC,
-            GOLEM_DB_WSS,
-            PRIVATE_KEY
-        )
+        try:
+            # Use direct constructor for golem-base-sdk 1.0.0
+            golem_client = GolemBaseClient(
+                GOLEM_DB_RPC,
+                GOLEM_DB_WSS,
+                PRIVATE_KEY
+            )
+        except Exception as e:
+            logger.error(f"GolemBaseClient creation failed: {e}")
+            raise ValueError(f"Failed to create Golem DB client: {e}")
     return golem_client
 
 # ========= STORAGE HELPERS =========
 async def store_humanity_verification(verification_data: Dict[str, Any]) -> str:
     """Store humanity verification data in Golem DB"""
-    client = await get_golem_client()
+    try:
+        client = await get_golem_client()
+    except Exception as e:
+        logger.error(f"Failed to get Golem client: {e}")
+        raise RuntimeError(f"Failed to initialize Golem DB client: {e}")
     
     entity_data = {
         "schema": "humanity_verification_v1",


### PR DESCRIPTION
- Remove non-existent create_rw_client static method
- Use direct GolemBaseClient constructor for SDK 1.0.0
- Add comprehensive error handling for client creation
- Resolves TypeError: Cannot read properties of undefined (reading 'create_rw_client')
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Golem DB client initialization by switching to the direct GolemBaseClient constructor for SDK 1.0.0 and adding robust error handling. Prevents the TypeError caused by the missing create_rw_client method and surfaces clearer failure messages.

- **Bug Fixes**
  - Replaced create_rw_client call with GolemBaseClient(...) in get_golem_client.
  - Wrapped client creation and retrieval in try/except with logged errors and clear exceptions.
  - Propagates initialization failures in store_humanity_verification.

<!-- End of auto-generated description by cubic. -->

